### PR TITLE
Adaptions for incremental solver.

### DIFF
--- a/webdslstatix/desugar/desugar-ui.str
+++ b/webdslstatix/desugar/desugar-ui.str
@@ -3,33 +3,35 @@ module desugar/desugar-ui
 imports
   src-gen/signatures/-
 
+  desugar/utils
+
 rules
 
   normalize-ui : Define(mods, x, fargs, targs, telements) -> DefinePage(newMods, x, fargs, targs, telements)
     where
-        <elem> (Page(), mods)
+        <elem(raw-eq)> (Page(), mods)
       ; newMods := <filter(not(?Page()))> mods
 
 //  normalize-ui : Define([], x, fargs, targs, telements) -> DefineTemplate([], x, fargs, targs, telements)
 
   normalize-ui : Define(mods, x, fargs, targs, telements) -> DefineTemplate(newMods, x, fargs, targs, telements)
     where
-        <elem> (Template(), mods)
+        <elem(raw-eq)> (Template(), mods)
       ; <not(fetch-elem(?Email()))> mods
       ; newMods := <filter(not(?Template()))> mods
 
   normalize-ui : Define(mods, x, fargs, targs, telements) -> DefineTemplate(mods, x, fargs, targs, telements)
     where
-        <elem> (AjaxTemplate(), mods)
+        <elem(raw-eq)> (AjaxTemplate(), mods)
 
   normalize-ui : Define(mods, x, fargs, targs, telements) -> DefineEmail(newMods, x, fargs, targs, telements)
     where
-        <elem> (Email(), mods)
+        <elem(raw-eq)> (Email(), mods)
       ; newMods := <filter(not(?Email() <+ ?Template()))> mods
 
   normalize-ui : DefineTemplate(mods, x, fargs, targs, telements) -> DefineEmail(newMods, x, fargs, targs, telements)
     where
-        <elem> (Email(), mods)
+        <elem(raw-eq)> (Email(), mods)
       ; newMods := <filter(not(?Email()))> mods
 
   normalize-ui : Define(mods, x, fargs, targs, telements) -> DefineTemplate(mods, x, fargs, targs, telements)

--- a/webdslstatix/desugar/utils.str
+++ b/webdslstatix/desugar/utils.str
@@ -11,3 +11,5 @@ rules
     explode-string
     ; [to-lower | id]
     ; implode-string
+
+  raw-eq = strip-annos; eq

--- a/webdslstatix/trans/static-semantics/actions/built-ins.stx
+++ b/webdslstatix/trans/static-semantics/actions/built-ins.stx
@@ -2,6 +2,7 @@ module static-semantics/actions/built-ins
 
 imports
   static-semantics/types/built-ins
+  static-semantics/webdsl-built-ins
   static-semantics/webdsl-types
   static-semantics/webdsl
 
@@ -22,43 +23,43 @@ rules
     url       == url(s),
     entity    == entity(s),
 
-    declareFunction(s, "now"     , []               , datetime),
-    declareFunction(s, "today"   , []               , date),
-    declareFunction(s, "Date"    , [string, string] , date),
-    declareFunction(s, "Date"    , [string]         , date),
-    declareFunction(s, "Time"    , [string, string] , time),
-    declareFunction(s, "Time"    , [string]         , time),
-    declareFunction(s, "DateTime", [string, string] , datetime),
-    declareFunction(s, "DateTime", [string]         , datetime),
-    declareFunction(s, "random"  , [int, int]       , int),
-    declareFunction(s, "random"  , [int]            , int),
-    declareFunction(s, "random"  , []               , float),
-    declareFunction(s, "url"     , [string]         , url),
+    declareBuiltInFunction(s, "now"     , []               , datetime),
+    declareBuiltInFunction(s, "today"   , []               , date),
+    declareBuiltInFunction(s, "Date"    , [string, string] , date),
+    declareBuiltInFunction(s, "Date"    , [string]         , date),
+    declareBuiltInFunction(s, "Time"    , [string, string] , time),
+    declareBuiltInFunction(s, "Time"    , [string]         , time),
+    declareBuiltInFunction(s, "DateTime", [string, string] , datetime),
+    declareBuiltInFunction(s, "DateTime", [string]         , datetime),
+    declareBuiltInFunction(s, "random"  , [int, int]       , int),
+    declareBuiltInFunction(s, "random"  , [int]            , int),
+    declareBuiltInFunction(s, "random"  , []               , float),
+    declareBuiltInFunction(s, "url"     , [string]         , url),
 
-    declareFunction(s, "randomUUID"     , []      , uuid),
-    declareFunction(s, "UUIDFromString" , [string], uuid),
+    declareBuiltInFunction(s, "randomUUID"     , []      , uuid),
+    declareBuiltInFunction(s, "UUIDFromString" , [string], uuid),
 
-    declareFunction(s, "getSessionManager", [], definedTypeNoRef(s, "SessionManager")),
+    declareBuiltInFunction(s, "getSessionManager", [], definedTypeNoRef(s, "SessionManager")),
 
-    declareFunction(s, "cancel"  , [], void),
-    declareFunction(s, "rollback", [], void),
-    declareFunction(s, "flush"   , [], void),
+    declareBuiltInFunction(s, "cancel"  , [], void),
+    declareBuiltInFunction(s, "rollback", [], void),
+    declareBuiltInFunction(s, "flush"   , [], void),
 
-    declareFunction(s, "getValidationErrorsByName", [string], LIST(string)),
+    declareBuiltInFunction(s, "getValidationErrorsByName", [string], LIST(string)),
 
-    declareFunction(s, "getHttpMethod"          , []      , string),
-    declareFunction(s, "getRequestParameter"    , [string], string),
-    declareFunction(s, "getRequestParameterList", [string], LIST(string)),
-    declareFunction(s, "readRequestBody"        , []      , string),
+    declareBuiltInFunction(s, "getHttpMethod"          , []      , string),
+    declareBuiltInFunction(s, "getRequestParameter"    , [string], string),
+    declareBuiltInFunction(s, "getRequestParameterList", [string], LIST(string)),
+    declareBuiltInFunction(s, "readRequestBody"        , []      , string),
 
-    declareFunction(s, "attribute"          , [string]        , string),
-    declareFunction(s, "attribute"          , [string, string], string),
-    declareFunction(s, "hasNotNullAttribute", []              , bool),
+    declareBuiltInFunction(s, "attribute"          , [string]        , string),
+    declareBuiltInFunction(s, "attribute"          , [string, string], string),
+    declareBuiltInFunction(s, "hasNotNullAttribute", []              , bool),
 
-    declareFunction(s, "message", [string], void),
-    declareFunction(s, "log"    , [object], void),
+    declareBuiltInFunction(s, "message", [string], void),
+    declareBuiltInFunction(s, "log"    , [object], void),
 
-    declareFunction(s, "assert", [bool], void),
-    declareFunction(s, "assert", [bool, string], void),
+    declareBuiltInFunction(s, "assert", [bool], void),
+    declareBuiltInFunction(s, "assert", [bool, string], void),
 
-    declareFunction(s, "loadEntity", [string, uuid], entity).
+    declareBuiltInFunction(s, "loadEntity", [string, uuid], entity).

--- a/webdslstatix/trans/static-semantics/actions/functions.stx
+++ b/webdslstatix/trans/static-semantics/actions/functions.stx
@@ -99,7 +99,7 @@ rules // function definitions
     declareParameters(s_function, zipArgTypes(args, argTypes)),
     new s_body, s_body -P-> s_function,
     stmtsOk(s_body, stmts, returnType),
-    declFunctionGlobal(s_outer, name, argTypes, returnType).
+    declFunctionGlobal(s_outer, name, FUNCTION_ORIGIN(args), argTypes, returnType).
 
   entityFunctionOk : scope * Function * BOOL
   entityFunctionOk(s_ent, Function(name, FormalArgs(args), OptSortSome(returnSort), Block(stmts)), static) :- { argTypes returnType s_function s_body }
@@ -109,7 +109,7 @@ rules // function definitions
     declareParameters(s_function, zipArgTypes(args, argTypes)),
     new s_body, s_body -P-> s_function,
     stmtsOk(s_body, stmts, returnType),
-    declFunctionEntity(s_ent, name, argTypes, returnType, static),
+    declFunctionEntity(s_ent, name, FUNCTION_ORIGIN(args), argTypes, returnType, static),
     noDuplicateFunDefsEntity(s_ent, name, argTypes).
 
   entityFunctionOk(s_ent, Function(name@"save", FormalArgs([]), _, _), _) :-
@@ -125,14 +125,14 @@ rules // function definitions
 
   // declare a function in a given scope
   // and define the relation typeOfFunDecl with signature (argument types  * return type)
-  declFunctionGlobal : scope * string * list(TYPE) * TYPE
-  declFunctionGlobal(s, f, args, return) :-
-    declareFunction(s, f, args, return),
+  declFunctionGlobal : scope * string * ORIGIN * list(TYPE) * TYPE
+  declFunctionGlobal(s, f, origin, args, return) :-
+    declareFunction(s, f, origin, args, return),
     noDuplicateFunDefsGlobal(s, f, args).
 
-  declFunctionEntity : scope * string * list(TYPE) * TYPE * BOOL
-  declFunctionEntity(s, f, args, return, TRUE()) :- declareStaticFunction(s, f, args, return).
-  declFunctionEntity(s, f, args, return, FALSE()) :- declareFunction(s, f, args, return).
+  declFunctionEntity : scope * string * ORIGIN * list(TYPE) * TYPE * BOOL
+  declFunctionEntity(s, f, origin, args, return, TRUE()) :- declareStaticFunction(s, f, origin, args, return).
+  declFunctionEntity(s, f, origin, args, return, FALSE()) :- declareFunction(s, f, origin, args, return).
 
   // map syntactic types to semantic types
   typesOfArgs maps typeOfArg(*, list(*)) = list(*)
@@ -156,9 +156,9 @@ rules // function definitions
   noDuplicateFunDefsEntity : scope * string * list(TYPE)
   noDuplicateFunDefsEntity(s, f, types) :- { ps }
     query function filter EXTEND?
-                   and { f' :- f' == (f, _) }
+                   and { f' :- f' == (f, _, _) }
                    in s |-> ps,
-    amountOfFunDeclsWithArgs(filterFunctionResults(typesOf(ps), FALSE()), types, 0) == 1
+    amountOfFunDeclsWithArgs(filterFunctionResults(typesOfStripOrigin(ps), FALSE()), types, 0) == 1
         | error $[Function with name [f] and argument types [types] is already defined] @f. // correct error message for tests
 
   // helper function for noDuplicateFunDefs that counts the amount of function with a given name and argument types

--- a/webdslstatix/trans/static-semantics/entities/built-ins.stx
+++ b/webdslstatix/trans/static-semantics/entities/built-ins.stx
@@ -6,6 +6,7 @@ imports
   static-semantics/entities/annotations
 
   static-semantics/webdsl-entities
+  static-semantics/webdsl-built-ins
   static-semantics/webdsl
 
 rules
@@ -22,9 +23,9 @@ rules
     declareVar(s_ent, "name"     , string(s)), declareAnnotations(s_ent, "name", [OVERRIDABLE(), NAME(), DERIVED()]),
     declareVar(s_ent, "created"  , datetime(s)),
     declareVar(s_ent, "modified" , datetime(s)),
-    declareFunction(s_ent, "save"  , [], VOID()),
-    declareFunction(s_ent, "delete", [], VOID()), // TO-DO: not allowed on session entities and global vars
-    declareFunction(s_object, "toString", [], string(s)),
+    declareBuiltInFunction(s_ent, "save"  , [], VOID()),
+    declareBuiltInFunction(s_ent, "delete", [], VOID()), // TO-DO: not allowed on session entities and global vars
+    declareBuiltInFunction(s_object, "toString", [], string(s)),
 
     new s_sessionmessage, s_sessionmessage -INHERIT-> s_ent,
     declareType(s, "SessionMessage", ENTITY("SessionMessage", s_sessionmessage)),

--- a/webdslstatix/trans/static-semantics/entities/generated-functions.stx
+++ b/webdslstatix/trans/static-semantics/entities/generated-functions.stx
@@ -22,18 +22,18 @@ rules
 
   declareLoadOrFindEntity : scope * string * string * string * string * string * TYPE * BOOL
   declareLoadOrFindEntity(s, loadName, _, _, _, _, t, FALSE()) :-
-    declareFunction(s, loadName, [uuid(s)], t).
+    declareFunction(s, loadName, GENERATED_ORIGIN(1), [uuid(s)], t).
 
   declareLoadOrFindEntity(s, _, findName, getUniqueName, isUniqueName, isUniqueIdName, t, TRUE()) :- { s_ent idName idType bool }
     bool == bool(s),
     t == ENTITY(_, s_ent),
     resolveAnnotationByAnno(s_ent, ID()) == [(_, (idName, _))],
     idType == propertyType(s_ent, idName),
-    declareFunction(s, findName, [idType], t),
-    declareFunction(s, getUniqueName, [idType], t),
-    declareFunction(s, isUniqueName, [t], bool),
-    declareFunction(s, isUniqueIdName, [idType], bool),
-    declareFunction(s, isUniqueIdName, [idType, t], bool).
+    declareFunction(s, findName,       GENERATED_ORIGIN(1), [idType], t),
+    declareFunction(s, getUniqueName,  GENERATED_ORIGIN(1), [idType], t),
+    declareFunction(s, isUniqueName,   GENERATED_ORIGIN(1), [t], bool),
+    declareFunction(s, isUniqueIdName, GENERATED_ORIGIN(1), [idType], bool),
+    declareFunction(s, isUniqueIdName, GENERATED_ORIGIN(2), [idType, t], bool).
 
 rules
 
@@ -50,5 +50,5 @@ rules
   declareFindEntityByProperty : scope * string * string * TYPE * TYPE * BOOL
   declareFindEntityByProperty(_, _, _, _, _, FALSE()).
   declareFindEntityByProperty(s, findByPropName, findByPropLikeName, entType, propType, TRUE()) :-
-    declareFunction(s, findByPropName, [propType], LIST(entType)),
-    declareFunction(s, findByPropLikeName, [propType], LIST(entType)).
+    declareFunction(s, findByPropName, PROP_ORIGIN(), [propType], LIST(entType)),
+    declareFunction(s, findByPropLikeName, PROP_ORIGIN(), [propType], LIST(entType)).

--- a/webdslstatix/trans/static-semantics/types/built-ins.stx
+++ b/webdslstatix/trans/static-semantics/types/built-ins.stx
@@ -4,6 +4,7 @@ imports
   static-semantics/actions/functions
 
   static-semantics/webdsl-actions
+  static-semantics/webdsl-built-ins
   static-semantics/webdsl-entities
   static-semantics/webdsl-native
   static-semantics/webdsl-types
@@ -118,28 +119,28 @@ rules
     float == float(s),
 
     new s_int, declareExtendScope(s, "Int", s_int),
-    declFunctionEntity(s_int, "floatValue", [], float, FALSE()),
+    declBuiltInFunctionEntity(s_int, "floatValue", [], float, FALSE()),
 
     new s_file, declareExtendScope(s, "File", s_file),
-    declFunctionEntity(s_file, "download"           , []      , VOID(), FALSE()),
-    declFunctionEntity(s_file, "download"           , [string], VOID(), FALSE()),
-    declFunctionEntity(s_file, "fileName"           , []      , string, FALSE()),
-    declFunctionEntity(s_file, "fileNameForDownload", []      , string, FALSE()),
+    declBuiltInFunctionEntity(s_file, "download"           , []      , VOID(), FALSE()),
+    declBuiltInFunctionEntity(s_file, "download"           , [string], VOID(), FALSE()),
+    declBuiltInFunctionEntity(s_file, "fileName"           , []      , string, FALSE()),
+    declBuiltInFunctionEntity(s_file, "fileNameForDownload", []      , string, FALSE()),
 
     declareExtendScope(s, "Image", s_file), // also expose file functions to image
     new s_image, declareExtendScope(s, "Image", s_image),
-    declFunctionEntity(s_image, "resize"   , [int, int]          , VOID()  , FALSE()),
-    declFunctionEntity(s_image, "crop"     , [int, int, int, int], VOID()  , FALSE()),
-    declFunctionEntity(s_image, "getWidth" , []                  , int     , FALSE()),
-    declFunctionEntity(s_image, "getHeight", []                  , int     , FALSE()),
-    declFunctionEntity(s_image, "clone"    , []                  , image(s), FALSE()),
+    declBuiltInFunctionEntity(s_image, "resize"   , [int, int]          , VOID()  , FALSE()),
+    declBuiltInFunctionEntity(s_image, "crop"     , [int, int, int, int], VOID()  , FALSE()),
+    declBuiltInFunctionEntity(s_image, "getWidth" , []                  , int     , FALSE()),
+    declBuiltInFunctionEntity(s_image, "getHeight", []                  , int     , FALSE()),
+    declBuiltInFunctionEntity(s_image, "clone"    , []                  , image(s), FALSE()),
 
     new s_float, declareExtendScope(s, "Float", s_float),
-    declFunctionEntity(s_float, "round" , [], int, FALSE()),
-    declFunctionEntity(s_float, "floor" , [], int, FALSE()),
-    declFunctionEntity(s_float, "ceil"  , [], int, FALSE()),
-    declFunctionEntity(s_float, "log"   , [], float, FALSE()),
-    declFunctionEntity(s_float, "log2"  , [], float, FALSE()).
+    declBuiltInFunctionEntity(s_float, "round" , [], int, FALSE()),
+    declBuiltInFunctionEntity(s_float, "floor" , [], int, FALSE()),
+    declBuiltInFunctionEntity(s_float, "ceil"  , [], int, FALSE()),
+    declBuiltInFunctionEntity(s_float, "log"   , [], float, FALSE()),
+    declBuiltInFunctionEntity(s_float, "log2"  , [], float, FALSE()).
 
 rules // built-in functions and properties for built-in generic type List
 

--- a/webdslstatix/trans/static-semantics/ui/actions.stx
+++ b/webdslstatix/trans/static-semantics/ui/actions.stx
@@ -48,12 +48,12 @@ rules // action definitions
     argTypes == typesOfArgs(s, args),
     declareParameters(s_fun, zipArgTypes(args, argTypes)),
     new s_fun_body, s_fun_body -P-> s_fun,
-    optionallyDeclareAction(s_pha, a, argTypes, declare),
+    optionallyDeclareAction(s_pha, a, args, argTypes, declare),
     stmtsOk(s_fun_body, stmts, PAGE(_, _)).
 
-  optionallyDeclareAction : scope * string * list(TYPE) * BOOL
-  optionallyDeclareAction(_, _, _, FALSE()).
-  optionallyDeclareAction(s, a, ts, TRUE()) :- declareAction(s, a, ts).
+  optionallyDeclareAction : scope * string * list(FormalArg) * list(TYPE) * BOOL
+  optionallyDeclareAction(_, _, _, _, FALSE()).
+  optionallyDeclareAction(s, a, args, ts, TRUE()) :- declareAction(s, a, FUNCTION_ORIGIN(args), ts).
 
   defOk(_, Action2Definition(Action(_, a, _, _))) :- false | error $[Actions are only allowed in pages and templates] @a.
 

--- a/webdslstatix/trans/static-semantics/webdsl-ac.stx
+++ b/webdslstatix/trans/static-semantics/webdsl-ac.stx
@@ -10,6 +10,7 @@ imports
   static-semantics/ui/template-calls
 
   static-semantics/webdsl-actions
+  static-semantics/webdsl-built-ins
   static-semantics/webdsl-entities
   static-semantics/webdsl-types
   static-semantics/webdsl
@@ -28,9 +29,9 @@ rules // built-ins
     declareType(s_decl, "securityContext", ENTITY("securityContext", s_securityContext)),
     declareVar(s_decl, "securityContext", ENTITY("securityContext", s_securityContext)),
 
-    declareFunction(s_decl, "loggedIn", [], bool),
-    declareFunction(s_decl, "logout", [], entity),
-    declareFunction(s_decl, "principalAsEntity", [], entity),
+    declareBuiltInFunction(s_decl, "loggedIn", [], bool),
+    declareBuiltInFunction(s_decl, "logout", [], entity),
+    declareBuiltInFunction(s_decl, "principalAsEntity", [], entity),
 
     declareTemplate(s_decl, "login", []),
     declareTemplate(s_decl, "logout", []),
@@ -195,12 +196,12 @@ rules // predicates
     declareVar(s_predicate, "principal", principalType),
     declareVar(s_predicate, "loggedIn", bool),
     equalType(typeOfExp(s_predicate, exp), bool) | error $[Predicate should contain a Bool expression] @exp, // correct error message for tests
-    declPredicate(s, p, argTypes, bool, global).
+    declPredicate(s, p, FUNCTION_ORIGIN(args), argTypes, bool, global).
 
   // last bool arg denotes if the scope is global
-  declPredicate : scope * string * list(TYPE) * TYPE * BOOL
-  declPredicate(s, p, argTypes, return, TRUE()) :- declFunctionGlobal(s, p, argTypes, return).
-  declPredicate(s, p, argTypes, return, FALSE()) :- declFunctionEntity(s, p, argTypes, return, FALSE()).
+  declPredicate : scope * string * ORIGIN * list(TYPE) * TYPE * BOOL
+  declPredicate(s, p, origin, argTypes, return, TRUE()) :- declFunctionGlobal(s, p, origin, argTypes, return).
+  declPredicate(s, p, origin, argTypes, return, FALSE()) :- declFunctionEntity(s, p, origin, argTypes, return, FALSE()).
 
 rules // pointcuts
 

--- a/webdslstatix/trans/static-semantics/webdsl-built-ins.stx
+++ b/webdslstatix/trans/static-semantics/webdsl-built-ins.stx
@@ -1,0 +1,15 @@
+module static-semantics/webdsl-built-ins
+
+imports
+  static-semantics/actions/functions
+
+  static-semantics/webdsl
+
+rules
+
+  declareBuiltInFunction : scope * string * list(TYPE) * TYPE
+  declareBuiltInFunction(s, f, args, return) :- declareFunction(s, f, BUILTIN_ORIGIN(args), args, return).
+
+  declBuiltInFunctionEntity : scope * string * list(TYPE) * TYPE * BOOL
+  declBuiltInFunctionEntity(s, f, args, return, static) :-
+    declFunctionEntity(s, f, BUILTIN_ORIGIN(args), args, return, static).

--- a/webdslstatix/trans/static-semantics/webdsl-entities.stx
+++ b/webdslstatix/trans/static-semantics/webdsl-entities.stx
@@ -68,18 +68,9 @@ rules // entity declaration
   declExtendEntity(s, entity_name, bodydecs) :- {s_extend_entity entity_scopes}
     resolveType(s, entity_name) == [(_, (_, ENTITY(_, _)))] | error $[Entity [entity_name] is not defined],
     new s_extend_entity, s_extend_entity -DEF-> s,
-    declareExtendScopeIfDefined(s, entity_name, s_extend_entity, entityDeclaredB(resolveType(s, entity_name))),
+    declareExtendScope(s, entity_name, s_extend_entity), // declare entity_scope to be linked to entity_name
+    extendScopes(resolveExtendScope(s, entity_name), s_extend_entity),
     declEntityBody(s_extend_entity, entity_name, bodydecs).
-
-  declareExtendScopeIfDefined : scope * string * scope * BOOL
-  declareExtendScopeIfDefined(_, _, _, FALSE()).
-  declareExtendScopeIfDefined(s, name, s_extend, TRUE()) :-
-    declareExtendScope(s, name, s_extend), // declare entity_scope to be linked to entity_name
-    extendScopes(resolveExtendScope(s, name), s_extend).
-
-  entityDeclaredB : list((path * (string * TYPE))) -> BOOL
-  entityDeclaredB(_) = FALSE().
-  entityDeclaredB([(_, (_, ENTITY(_, _)))]) = TRUE().
 
   noCircularInheritance : scope
   noCircularInheritance(s_ent) :- {res}

--- a/webdslstatix/trans/static-semantics/webdsl-native.stx
+++ b/webdslstatix/trans/static-semantics/webdsl-native.stx
@@ -83,12 +83,12 @@ rules // native class functions
   nativeClassFunctionOk(s, s_class, NCFunction(NCFunctionStatic(), f, args, NCFunctionReturn(return))) :- {argTypes returnType}
     argTypes   == typesOfNativeTypes(s, args),
     returnType == typeOfNativeType(s, return),
-    declareStaticFunction(s_class, f, argTypes, returnType).
+    declareStaticFunction(s_class, f, NATIVE_FUNCTION_ORIGIN(args), argTypes, returnType).
 
   nativeClassFunctionOk(s, s_class, NCFunction(NCFunctionStaticNone(), f, args, NCFunctionReturn(return))) :- {argTypes returnType}
     argTypes   == typesOfNativeTypes(s, args),
     returnType == typeOfNativeType(s, return),
-    declareFunction(s_class, f, argTypes, returnType).
+    declareFunction(s_class, f, NATIVE_FUNCTION_ORIGIN(args), argTypes, returnType).
 
 rules // constructors
 
@@ -97,11 +97,11 @@ rules // constructors
   declareNativeClassConstructor(_, _, _, _).
   declareNativeClassConstructor(s, s_class, name, NCConstructor(args)) :- {argTypes}
     argTypes == typesOfNativeTypes(s, args),
-    declFunctionGlobal(s, name, argTypes, NATIVECLASS(name, s_class)).
+    declFunctionGlobal(s, name, NATIVE_FUNCTION_ORIGIN(args), argTypes, NATIVECLASS(name, s_class)).
 
   declareNativeClassConstructor(s, s_class, name, NCConstructorFromStatic(_, args)) :- {argTypes}
     argTypes == typesOfNativeTypes(s, args),
-    declFunctionGlobal(s, name, argTypes, NATIVECLASS(name, s_class)).
+    declFunctionGlobal(s, name, NATIVE_FUNCTION_ORIGIN(args), argTypes, NATIVECLASS(name, s_class)).
 
 rules // typing of expressions
 

--- a/webdslstatix/trans/static-semantics/webdsl-native.stx
+++ b/webdslstatix/trans/static-semantics/webdsl-native.stx
@@ -50,7 +50,8 @@ rules // native class extending
   defOk(s, ExtendNativeClass(c, NCAlias(alias), elems)) :- { s_extend_class class_scopes }
     resolveType(s, alias) == [(_, (_, NATIVECLASS(_, _)))] | error $[Native class [alias] is not defined],
     new s_extend_class, s_extend_class -DEF-> s,
-    declareExtendScopeIfDefined(s, alias, s_extend_class, nativeClassDeclaredB(resolveType(s, alias))),
+    declareExtendScope(s, alias, s_extend_class), // declare entity_scope to be linked to entity_name
+    extendScopes(resolveExtendScope(s, alias), s_extend_class),
     nativeClassElementsOk(s, s_extend_class, elems).
 
   nativeClassDeclaredB : list((path * (string * TYPE))) -> BOOL

--- a/webdslstatix/trans/static-semantics/webdsl.stx
+++ b/webdslstatix/trans/static-semantics/webdsl.stx
@@ -26,12 +26,19 @@ imports
 signature
 
   sorts
-    TYPE // semantic type
-    BOOL // used as return values of functional constraints
+    TYPE   // semantic type
+    BOOL   // used as return values of functional constraints
+    ORIGIN // dummy data: used to guide scope graph differ
 
   constructors
     TRUE : BOOL
     FALSE : BOOL
+
+    FUNCTION_ORIGIN: list(FormalArg) -> ORIGIN
+    NATIVE_FUNCTION_ORIGIN: list(NativeType) -> ORIGIN
+    BUILTIN_ORIGIN: list(TYPE) -> ORIGIN
+    PROP_ORIGIN: ORIGIN // prop names should be unique. TODO: how about non-unique properties in incorrect programs?
+    GENERATED_ORIGIN: int -> ORIGIN  // unary identity-derived function
 
   name-resolution
     labels
@@ -55,7 +62,7 @@ signature
     template : string * scope
     ac       : string * scope
 
-    function : string * scope
+    function : string * ORIGIN * scope
 
     var      : string * scope
 
@@ -110,6 +117,11 @@ rules // type declaration and resolving
   typesOf maps typeOf(list(*)) = list(*)
   typeOf : (path * (string * scope)) -> (path * (string * TYPE))
   typeOf((p, (x, s))) = (p, (x, t)) :-
+    query typeOf filter e in s |-> [(_, t)].
+
+  typesOfStripOrigin maps typeOfStripOrigin(list(*)) = list(*)
+  typeOfStripOrigin : (path * (string * ORIGIN * scope)) -> (path * (string * TYPE))
+  typeOfStripOrigin((p, (x, _, s))) = (p, (x, t)) :-
     query typeOf filter e in s |-> [(_, t)].
 
   simpleTypeOf : scope -> TYPE
@@ -221,40 +233,40 @@ rules // ac rules
 
 rules // function declaration and resolving
 
-  declareFunction : scope * string * list(TYPE) * TYPE
-  declareFunction(s, f, args, return) :- declareFunction_internal(s, f, args, return, FALSE()).
+  declareFunction : scope * string * ORIGIN * list(TYPE) * TYPE
+  declareFunction(s, f, origin, args, return) :- declareFunction_internal(s, f, origin, args, return, FALSE()).
 
-  declareStaticFunction : scope * string * list(TYPE) * TYPE
-  declareStaticFunction(s, f, args, return) :- declareFunction_internal(s, f, args, return, TRUE()).
+  declareStaticFunction : scope * string * ORIGIN * list(TYPE) * TYPE
+  declareStaticFunction(s, f, origin, args, return) :- declareFunction_internal(s, f, origin, args, return, TRUE()).
 
-  declareFunction_internal : scope * string * list(TYPE) * TYPE * BOOL
-  declareFunction_internal(s, f, args, return, static) :- { s_type }
+  declareFunction_internal : scope * string * ORIGIN * list(TYPE) * TYPE * BOOL
+  declareFunction_internal(s, f, origin, args, return, static) :- { s_type }
     s_type == withType(FUNCTION(f, args, return, static)),
-    !function[f, s_type] in s.
+    !function[f, origin, s_type] in s.
 
   resolveFunction : scope * string -> list((path * (string * TYPE)))
-  resolveFunction(s, f) = filterFunctionResults(typesOf(ps), FALSE()) :-
+  resolveFunction(s, f) = filterFunctionResults(typesOfStripOrigin(ps), FALSE()) :-
     query function filter P* F* ((EXTEND? (INHERIT EXTEND?)*) | (DEF? (IMPORT | IMPORTLIB)?))
-                   and { f' :- f' == (f, _) }
+                   and { f' :- f' == (f, _, _) }
                    in s |-> ps.
 
   resolveEntityFunction : scope * string -> list((path * (string * TYPE)))
-  resolveEntityFunction(s, x) = filterFunctionResults(typesOf(ps), FALSE()) :-
+  resolveEntityFunction(s, x) = filterFunctionResults(typesOfStripOrigin(ps), FALSE()) :-
     query function filter EXTEND? (INHERIT EXTEND?)*
-                   and { x' :- x' == (x, _) }
+                   and { x' :- x' == (x, _, _) }
                    min $ < INHERIT, EXTEND < INHERIT // do not shadow EXTEND with $
-                   and { (f, T1), (f, T2) :- {args}
+                   and { (f, _, T1), (f, _, T2) :- {args}
                      simpleTypeOf(T1) == FUNCTION(f, args, _, _),
                      simpleTypeOf(T2) == FUNCTION(f, args, _, _)
                    } // only shadow when function has the same name and argument types
                    in s |-> ps.
 
   resolveStaticEntityFunction : scope * string -> list((path * (string * TYPE)))
-  resolveStaticEntityFunction(s, x) = filterFunctionResults(typesOf(ps), TRUE()) :-
+  resolveStaticEntityFunction(s, x) = filterFunctionResults(typesOfStripOrigin(ps), TRUE()) :-
     query function filter EXTEND? (INHERIT EXTEND?)*
-                   and { x' :- x' == (x, _) }
+                   and { x' :- x' == (x, _, _) }
                    min $ < INHERIT, EXTEND < INHERIT // do not shadow EXTEND with $
-                   and { (f, T1), (f, T2) :- {args}
+                   and { (f, _, T1), (f, _, T2) :- {args}
                      simpleTypeOf(T1) == FUNCTION(f, args, _, _),
                      simpleTypeOf(T2) == FUNCTION(f, args, _, _)
                    } // only shadow when function has the same name and argument types
@@ -269,15 +281,15 @@ rules // function declaration and resolving
 
 rules // action and placeholder declaration and resolving
 
-  declareAction : scope * string * list(TYPE)
-  declareAction(s, a, ts) :-
-    !function[a, withType(ACTION(a, ts))] in s,
+  declareAction : scope * string * ORIGIN * list(TYPE)
+  declareAction(s, a, origin, ts) :-
+    !function[a, origin, withType(ACTION(a, ts))] in s,
     resolveAction(s, a) == [(_, (_, ACTION(a, ts)))] | error $[Action [a] is defined multiple times] @a.
 
   resolveAction : scope * string -> list((path * (string * TYPE)))
-  resolveAction(s, a) = filterActionResults(typesOf(as)) :-
+  resolveAction(s, a) = filterActionResults(typesOfStripOrigin(as)) :-
     query function filter P*
-                   and { a' :- a' == (a, _) }
+                   and { a' :- a' == (a, _, _) }
                    in s |-> as.
 
   declarePlaceholder : scope * string


### PR DESCRIPTION
This PR implements two adaptions that make the specification work better with the incremental solver.
- There is an `origin` attached to function declarations. This allows the scope graph differ to distinguish between different overloads of a function.
- `extendentity` declarations don't do a check if the entity that is extended exists. This check made the declaration context-sensitive, which behaves badly with the incremental framework.